### PR TITLE
Fix handling of multiple asset files in a bundle

### DIFF
--- a/unitypack/__init__.py
+++ b/unitypack/__init__.py
@@ -264,6 +264,11 @@ class Asset:
 		self.name = buf.read_string()
 		self.header_size = buf.read_uint()
 		self.size = buf.read_uint()
+		self.meta_end = buf.tell()
+
+		# Skip resource asset files
+		if self.name.endswith("resource"):
+			return
 
 		buf.seek(offset + self.header_size - 4)
 		self.data = BytesIO(buf.read(self.size))
@@ -377,6 +382,7 @@ class AssetBundle:
 			asset = Asset()
 			asset.load(buf)
 			self.assets.append(asset)
+			buf.seek(asset.meta_end)
 
 
 def load(file):


### PR DESCRIPTION
Fixes crashing on bundle files that contain more than one asset file.
The asset metadata is given together sequentially after the bundle header, rather than at the beginning of each of asset file.
