### PR TITLE
Extract audio samples from AudioClips

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import fsb5
 import os
 import sys
 import unitypack
@@ -40,7 +41,13 @@ def handle_asset(asset):
 		d = obj.read()
 
 		if obj.type == "AudioClip":
-			write_to_file(d.name + ".fsb", d.data, mode="wb")
+			audio = fsb5.FSB5(d.data)
+			assert len(audio.samples) == 1
+			try:
+				write_to_file(d.name + "." + audio.get_sample_extension(), audio.rebuild_sample(audio.samples[0]), mode="wb")
+			except (ValueError, NotImplementedError, OSError) as e:
+				print('Got error: "%s" while rebuilding audio sample. Writing raw fsb instead' % e)
+				write_to_file(d.name + ".fsb", d.data, mode="wb")
 
 		elif obj.type == "Shader":
 			write_to_file(d.name + ".cg", d.script)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e git://github.com/synap5e/python-fsb5.git#egg=python-fsb5

--- a/unitypack/__init__.py
+++ b/unitypack/__init__.py
@@ -276,7 +276,10 @@ class Asset:
 		size = buf.read_uint()
 
 		ofs = buf.tell()
-		buf.seek(offset + header_size - 4)
+		if ret.is_resource:
+			buf.seek(offset + header_size - 4 - len(ret.name))
+		else:
+			buf.seek(offset + header_size - 4)
 		ret.data = BinaryReader(BytesIO(buf.read(size)), endian=">")
 		buf.seek(ofs)
 		return ret


### PR DESCRIPTION
Currently python-fsb5 supports MPEG and Vorbis samples. Unsupported formats will revert to extracting the .fsb.

Due to a bug in python-fsb5 roughly 5% of vorbis samples also fail to be extracted and .fsbs are extracted instead.

Note that vorbis support requires libogg and libvorbis to be installed/on the dynamic library path. If these libraries are not found the .fsb will be extracted instead.
