### PR TITLE
Fix streaming asset resolution for textures

### DIFF
--- a/unitypack/engine/__init__.py
+++ b/unitypack/engine/__init__.py
@@ -12,4 +12,4 @@ from .particle import EllipsoidParticleEmitter, MeshParticleEmitter, ParticleEmi
 from .physics import BoxCollider, BoxCollider2D, Collider, Collider2D, Rigidbody2D
 from .renderer import MeshRenderer, ParticleRenderer, ParticleSystemRenderer, Renderer
 from .text import TextAsset, TextMesh, Shader
-from .texture import Material, Sprite, Texture2D
+from .texture import Material, Sprite, Texture2D, StreamingInfo

--- a/unitypack/object.py
+++ b/unitypack/object.py
@@ -144,11 +144,9 @@ class ObjectInfo:
 
 				result = load_object(type, result)
 				if t == "StreamedResource":
-					if self.asset.bundle and self.asset.bundle.environment:
-						result.asset = self.asset.get_asset(result.source)
-					else:
-						logging.warning("StreamedResource not available without bundle")
-						result.asset = None
+					result.asset = self.resolve_streaming_asset(result.source)
+				elif t == "StreamingInfo":
+					result.asset = self.resolve_streaming_asset(result.path)
 
 		# Check to make sure we read at least as many bytes the tree says.
 		# We allow reading more for the case of alignment.
@@ -161,6 +159,10 @@ class ObjectInfo:
 			buf.align()
 
 		return result
+
+	def resolve_streaming_asset(self, path):
+		if len(path) > 0:
+			return self.asset.get_asset(path)
 
 
 class ObjectPointer:


### PR DESCRIPTION
Move the StreamedResource and StreamingInfo asset resolution into a function on Object, and let asset resolution work for non-bundles as well.