### PR TITLE
Continue on unsupported texture format

### DIFF
--- a/bin/unityextract
+++ b/bin/unityextract
@@ -130,7 +130,12 @@ class UnityExtract:
 				except ImportError:
 					print("WARNING: Pillow not available. Skipping %r." % (filename))
 					continue
-				image = d.image
+				try:
+					image = d.image
+				except NotImplementedError:
+					print("WARNING: Texture format not implemented. Skipping %r." % (filename))
+					continue
+
 				if image is None:
 					print("WARNING: %s is an empty image" % (filename))
 					continue


### PR DESCRIPTION
Right now, if unityextract encounters an unsupported texture format for a file, it throws an error and bails on the whole thing, even if there are remaining textures in a supported format that could be extracted.  It seems better in this situation to print a warning, which is what this commit does.

I don't write much code with Python, so please edit if you think there's a better way to handle this.