### PR TITLE
assets: compute CRC32

### DIFF
--- a/unitypack/asset.py
+++ b/unitypack/asset.py
@@ -1,7 +1,7 @@
 import logging
 import lzma
 import os
-from binascii import hexlify
+from binascii import hexlify, crc32
 from io import BytesIO
 from uuid import UUID
 
@@ -36,6 +36,7 @@ class Asset:
 			dec = lzma.LZMADecompressor()
 			data = dec.decompress(buf.read())
 			ret._buf = BinaryReader(BytesIO(data[header_size:]), endian=">")
+			ret.crc32 = crc32(data[header_size:])
 			ret._buf_ofs = 0
 			buf.seek(ofs)
 		else:
@@ -74,6 +75,7 @@ class Asset:
 		self.long_object_ids = False
 		self.tree = TypeMetadata(self)
 		self.loaded = False
+		self.crc32 = None
 
 	def __repr__(self):
 		return "<%s %s>" % (self.__class__.__name__, self.name)


### PR DESCRIPTION
This computes the CRC32 that Unity uses as the Asset Bundle Manifest CRC32, for purposes of comparing a file against a known CRC32, to make sure that the bundle was downloaded properly.

This is ... a very quick and dirty hack, because this will only compute the asset bundle CRC32 for compressed assets that were added a certain way. It's probably desirable to compute the CRC32 in all cases if you wish to add it at all, but I wanted to submit some sample code as an RFE instead of just begging for free development.

It looks like for non-compressed assets we don't pre-read them on parse, so would you mind suggesting a better location in the code to calculate this CRC32?

thanks,
--js