### PR TITLE
also treat .resS-files as resources

### DIFF
--- a/unitypack/asset.py
+++ b/unitypack/asset.py
@@ -86,7 +86,7 @@ class Asset:
 
 	@property
 	def is_resource(self):
-		return self.name.endswith(".resource")
+		return self.name.endswith(".resource") or self.name.endswith(".resS")
 
 	def load(self):
 		if self.is_resource:


### PR DESCRIPTION
Currently, only files ending with .resource are being treated as resource files, but also files with .resS should be treated this way:

https://github.com/HearthSim/UnityPack/wiki/Format-Documentation