### PR TITLE
Set base_path to directory of bundle file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ field or TextAsset's `m_Script` field. Using this, files can be "extracted" from
 bundles by using their `m_Name` and an appropriate extension. But doing so leaves out all
 the "unextractable" classes which one might want to deal with.
 
+**Note:** Unity3D files may sometimes reference external files. By default UnityPack will
+look for these files in the same directory as the Unity3D file.
+
 
 ## Usage
 

--- a/unitypack/__init__.py
+++ b/unitypack/__init__.py
@@ -1,4 +1,5 @@
 import pkg_resources
+from os.path import dirname
 
 
 __version__ = pkg_resources.require("unitypack")[0].version
@@ -8,7 +9,7 @@ def load(file, env=None):
 	from .environment import UnityEnvironment
 
 	if env is None:
-		env = UnityEnvironment()
+		env = UnityEnvironment(dirname(file.name))
 	return env.load(file)
 
 
@@ -16,5 +17,5 @@ def load_from_file(file, env=None):
 	from .environment import UnityEnvironment
 
 	if env is None:
-		env = UnityEnvironment()
+		env = UnityEnvironment(dirname(file.name))
 	return env.get_asset_by_filename(file)


### PR DESCRIPTION
(See #74) Currently, something like

    unityextract --all extracted/data.unity3d

will fail with `KeyError: "No such asset: 'sharedassets0.resource'"`, while

~~~ bash
cd extracted
unityextract --all data.unity3d
~~~

will work. This patch sets `base_path` to the same directory where the loaded Unity3D file is (by default), and mentions that Unity3D files can reference external files (for people who didn't know, like me).