### PR TITLE
Parse Unity 2019.1 asset bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+env
+dist
+build
+__pycache__
+*.egg-info

--- a/unitypack/type.py
+++ b/unitypack/type.py
@@ -52,7 +52,7 @@ class TypeTree:
 	def load_blob(self, buf):
 		num_nodes = buf.read_uint()
 		self.buffer_bytes = buf.read_uint()
-		node_bytes = 32 if self.format >= 20 else 24
+		node_bytes = 32 if self.format >= 19 else 24
 		node_data = BytesIO(buf.read(node_bytes * num_nodes))
 		self.data = buf.read(self.buffer_bytes)
 
@@ -81,8 +81,8 @@ class TypeTree:
 			curr.index = buf.read_uint()
 			curr.flags = buf.read_int()
 
-			if self.format >= 20:
-				unk1 = buf.read_int64() # zero bytes?
+			# consume unused bytes in the node (always zeros?)
+			buf.read(node_bytes - 24)
 
 	def get_string(self, offset):
 		if offset < 0:

--- a/unitypack/type.py
+++ b/unitypack/type.py
@@ -52,7 +52,7 @@ class TypeTree:
 	def load_blob(self, buf):
 		num_nodes = buf.read_uint()
 		self.buffer_bytes = buf.read_uint()
-		node_data = BytesIO(buf.read(24 * num_nodes))
+		node_data = BytesIO(buf.read(32 * num_nodes))
 		self.data = buf.read(self.buffer_bytes)
 
 		parents = [self]
@@ -79,6 +79,7 @@ class TypeTree:
 			curr.size = buf.read_int()
 			curr.index = buf.read_uint()
 			curr.flags = buf.read_int()
+			unk1 = buf.read_int64() # zero bytes?
 
 	def get_string(self, offset):
 		if offset < 0:

--- a/unitypack/type.py
+++ b/unitypack/type.py
@@ -52,7 +52,8 @@ class TypeTree:
 	def load_blob(self, buf):
 		num_nodes = buf.read_uint()
 		self.buffer_bytes = buf.read_uint()
-		node_data = BytesIO(buf.read(32 * num_nodes))
+		node_bytes = 32 if self.format >= 20 else 24
+		node_data = BytesIO(buf.read(node_bytes * num_nodes))
 		self.data = buf.read(self.buffer_bytes)
 
 		parents = [self]
@@ -79,7 +80,9 @@ class TypeTree:
 			curr.size = buf.read_int()
 			curr.index = buf.read_uint()
 			curr.flags = buf.read_int()
-			unk1 = buf.read_int64() # zero bytes?
+
+			if self.format >= 20:
+				unk1 = buf.read_int64() # zero bytes?
 
 	def get_string(self, offset):
 		if offset < 0:


### PR DESCRIPTION
Fixes #93 

At some point between Unity 2018.1 and 2019.2, the asset bundle format changed. In particular, type tree nodes grew from 24 bytes each to 32 bytes. This PR implements that change.