### PR TITLE
Fix UnityWeb/UnityRaw and add CRC computations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # UnityPack
-[![Build Status](https://api.travis-ci.org/HearthSim/UnityPack.svg?branch=master)](https://travis-ci.org/HearthSim/UnityPack)
 
 A library to deserialize Unity3D Assets and AssetBundles files (*.unity3d).
+
+## Fork Information
+
+This is a friendly fork of UnityPack to ease packaging for the Malie
+project. It contains fixes not yet upstreamed for UnityPack. The
+original author of UnityPack is Jerome LeClanche. Please do not seek
+support from the original author for patches introduced in this
+version, but please do contribute patches directly to the original
+project whenever possible.
+
+The base project is version 0.9.0. This fork will use versions
+starting at 0.9.1a0 to indicate a pre-release alpha for UnityPack
+0.9.1, indicating my hope to upstream these patches. This fork will
+release NO non-alpha versions to avoid interfering with the core
+project's versioning scheme.
 
 ## Dependencies
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = unitypack
-version = 0.9.0
+version = 0.9.1a0
 description = Python implementation of the .unity3d format
 author = nago <nago@malie.io>, Jerome Leclanche <jerome@leclan.ch>
 author_email = nago@malie.io

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,10 @@
 name = unitypack
 version = 0.9.0
 description = Python implementation of the .unity3d format
-author = Jerome Leclanche
-author_email = jerome@leclan.ch
-url = https://github.com/HearthSim/UnityPack
-download_url = https://github.com/HearthSim/UnityPack/tarball/master
+author = nago <nago@malie.io>, Jerome Leclanche <jerome@leclan.ch>
+author_email = nago@malie.io
+url = https://gitlab.com/malie-library/unitypack
+download_url = https://gitlab.com/malie-library/unitypack/-/archive/master/unitypack-master.tar.gz
 classifiers =
 	Development Status :: 4 - Beta
 	Intended Audience :: Developers

--- a/unitypack/asset.py
+++ b/unitypack/asset.py
@@ -12,36 +12,15 @@ from .utils import BinaryReader
 
 class Asset:
 	@classmethod
-	def from_bundle(cls, bundle, buf):
+	def from_bundle(cls, bundle, buf, name=None, offset=None, size=None):
 		ret = cls()
 		ret.bundle = bundle
 		ret.environment = bundle.environment
-		offset = buf.tell()
-		ret._buf = BinaryReader(buf, endian=">")
 
-		if bundle.is_unityfs:
-			ret._buf_ofs = buf.tell()
-			return ret
-
-		if not bundle.compressed:
-			ret.name = buf.read_string()
-			header_size = buf.read_uint()
-			buf.read_uint()  # size
-		else:
-			header_size = bundle.asset_header_size
-
-		# FIXME: this offset needs to be explored more
-		ofs = buf.tell()
-		if bundle.compressed:
-			dec = lzma.LZMADecompressor()
-			data = dec.decompress(buf.read())
-			ret._buf = BinaryReader(BytesIO(data[header_size:]), endian=">")
-			ret._buf_ofs = 0
-			buf.seek(ofs)
-		else:
-			ret._buf_ofs = offset + header_size - 4
-			if ret.is_resource:
-				ret._buf_ofs -= len(ret.name)
+		ret._buf = buf
+		ret.name = name
+		ret._buf_ofs = offset or buf.tell()
+		ret._size = size
 
 		return ret
 

--- a/unitypack/assetbundle.py
+++ b/unitypack/assetbundle.py
@@ -18,8 +18,6 @@ class AssetBundle:
 		self.assets = []
 
 	def __repr__(self):
-		if hasattr(self, "name"):
-			return "<%s %r>" % (self.__class__.__name__, self.name)
 		return "<%s>" % (self.__class__.__name__)
 
 	@property
@@ -131,9 +129,6 @@ class AssetBundle:
 			asset = Asset.from_bundle(self, storage)
 			asset.name = name
 			self.assets.append(asset)
-
-		# Hacky
-		self.name = self.assets[0].name
 
 
 class ArchiveBlockInfo:

--- a/unitypack/engine/texture.py
+++ b/unitypack/engine/texture.py
@@ -5,23 +5,42 @@ from .object import Object, field
 
 
 class TextureFormat(IntEnum):
+	# Primitive formats
 	Alpha8 = 1
 	ARGB4444 = 2
 	RGB24 = 3
 	RGBA32 = 4
 	ARGB32 = 5
+	# 6
 	RGB565 = 7
+	# 8
+	R16 = 9
 
 	# Direct3D
 	DXT1 = 10
+	# 11
 	DXT5 = 12
 
+	# Primitive formats (continued)
 	RGBA4444 = 13
 	BGRA32 = 14
+	RHalf = 15
+	RGHalf = 16
+	RGBAHalf = 17
+	RFloat = 18
+	RGFloat = 19
+	RGBAFloat = 20
+	# 21
+	RGB9E5 = 22
+	# 23
 
+	# BC[4-7]
 	BC6H = 24
 	BC7 = 25
+	BC4 = 26
+	BC5 = 27
 
+	# DXT Crunched
 	DXT1Crunched = 28
 	DXT5Crunched = 29
 
@@ -67,6 +86,10 @@ class TextureFormat(IntEnum):
 	# Nintendo 3DS-flavoured ETC
 	ETC_RGB4_3DS = 60
 	ETC_RGBA8_3DS = 61
+
+	# Additional Primitive formats
+	RG16 = 62
+	R8 = 63
 
 	# ETC crunched texture
 	ETC_RGB4Crunched = 64

--- a/unitypack/engine/texture.py
+++ b/unitypack/engine/texture.py
@@ -137,7 +137,7 @@ class Texture2D(Texture):
 	read_allowed = field("m_ReadAllowed")
 	format = field("m_TextureFormat", TextureFormat)
 	texture_dimension = field("m_TextureDimension")
-	mipmap = field("m_MipMap")
+	mip_count = field("m_MipCount")
 	complete_image_size = field("m_CompleteImageSize")
 	stream_data = field("m_StreamData", default=False)
 

--- a/unitypack/engine/texture.py
+++ b/unitypack/engine/texture.py
@@ -64,6 +64,23 @@ class TextureFormat(IntEnum):
 	ASTC_RGBA_10x10 = 58
 	ASTC_RGBA_12x12 = 59
 
+	# Nintendo 3DS-flavoured ETC
+	ETC_RGB4_3DS = 60
+	ETC_RGBA8_3DS = 61
+
+	# ETC crunched texture
+	ETC_RGB4Crunched = 64
+	ETC2_RGBA8Crunched = 65
+
+	# ASTC compressed HDR RGB(A)
+	ASTC_HDR_4x4 = 66
+	ASTC_HDR_5x5 = 67
+	ASTC_HDR_6x6 = 68
+	ASTC_HDR_8x8 = 69
+	ASTC_HDR_10x10 = 70
+	ASTC_HDR_12x12 = 71
+
+
 	@property
 	def pixel_format(self):
 		if self == TextureFormat.RGB24:

--- a/unitypack/utils.py
+++ b/unitypack/utils.py
@@ -1,3 +1,4 @@
+from _thread import RLock
 from binascii import crc32
 from io import DEFAULT_BUFFER_SIZE
 from os import SEEK_CUR
@@ -164,3 +165,54 @@ def stream_crc32(f, size, crc=0):
 		size = size - len(data)
 		_crc = crc32(data, _crc)
 	return _crc
+
+
+# This was borrowed from Python 3.8; by Carl Meyer.
+_NOT_FOUND = object()
+
+class cached_property:
+	def __init__(self, func):
+		self.func = func
+		self.attrname = None
+		self.__doc__ = func.__doc__
+		self.lock = RLock()
+
+	def __set_name__(self, owner, name):
+		if self.attrname is None:
+			self.attrname = name
+		elif name != self.attrname:
+			raise TypeError(
+				"Cannot assign the same cached_property to two different names "
+				f"({self.attrname!r} and {name!r})."
+			)
+
+	def __get__(self, instance, owner=None):
+		if instance is None:
+			return self
+		if self.attrname is None:
+			raise TypeError(
+				"Cannot use cached_property instance without calling __set_name__ on it.")
+		try:
+			cache = instance.__dict__
+		except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+			msg = (
+				f"No '__dict__' attribute on {type(instance).__name__!r} "
+				f"instance to cache {self.attrname!r} property."
+			)
+			raise TypeError(msg) from None
+		val = cache.get(self.attrname, _NOT_FOUND)
+		if val is _NOT_FOUND:
+			with self.lock:
+				# check if another thread filled cache while we awaited lock
+				val = cache.get(self.attrname, _NOT_FOUND)
+				if val is _NOT_FOUND:
+					val = self.func(instance)
+					try:
+						cache[self.attrname] = val
+					except TypeError:
+						msg = (
+							f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+							f"does not support item assignment for caching {self.attrname!r} property."
+						)
+						raise TypeError(msg) from None
+		return val

--- a/unitypack/utils.py
+++ b/unitypack/utils.py
@@ -57,6 +57,9 @@ class BinaryReader:
 	def read(self, *args):
 		return self.buf.read(*args)
 
+	def seekable(self):
+		return self.buf.seekable()
+
 	def seek(self, *args):
 		return self.buf.seek(*args)
 

--- a/unitypack/utils.py
+++ b/unitypack/utils.py
@@ -112,3 +112,25 @@ class BinaryReader:
 
 	def read_int64(self) -> int:
 		return struct.unpack(self.endian + "q", self.read(8))[0]
+
+
+class OffsetReader(BinaryReader):
+	"""
+	Create a BinaryReader class that records the current offset of buf,
+	and treats this offset as the new SEEK_SET position, translating
+	seek() and tell() requests as appropriate.
+	"""
+	def __init__(self, buf, endian=">"):
+		super().__init__(buf, endian)
+		self._offset = buf.tell()
+
+	def seek(self, offset, whence=0):
+		if whence == 0:
+			self.buf.seek(offset + self._offset, whence)
+		else:
+			# SEEK_CUR: This is just a DX, it relays as-is
+			# SEEK_END: This is a DX from the end, which has no Adjustment.
+			self.buk.seek(offset, whence)
+
+	def tell(self):
+		return self.buf.tell() - self._offset


### PR DESCRIPTION
Hi!

This should improve the bundle header decomposition. It was overreading into the asset area before, this should be a little more accurate, and the Asset initialization should now be greatly simplified. Unfortunately, I don't have a large corpus of files to test with, so I can't claim that it doesn't introduce any regressions.

This also adds CRC computations to the bundle, which can be useful for verifying that streamed bundles have downloaded correctly. Games like Pokemon TCG use both Headered and Headerless CRCs to verify bundles.