### PR TITLE
Fix off-by-one error for 2019.4 bundles

### DIFF
--- a/unitypack/type.py
+++ b/unitypack/type.py
@@ -151,6 +151,9 @@ class TypeMetadata:
 					tree.load(buf)
 					self.type_trees[class_id] = tree
 
+				if format >= 21:
+					unk1 = buf.read(4)
+
 		else:
 			num_fields = buf.read_int()
 			for i in range(num_fields):

--- a/unitypack/type.py
+++ b/unitypack/type.py
@@ -151,6 +151,7 @@ class TypeMetadata:
 					tree.load(buf)
 					self.type_trees[class_id] = tree
 
+				# 4 unidentified bytes at the end of a type tree in 2019.4
 				if format >= 21:
 					unk1 = buf.read(4)
 


### PR DESCRIPTION
Each type tree in Unity 2019.4 (format 21) has an extra 4 bytes at the end compared to Unity 2019.1 (format 19), whose purpose is unknown. This PR consumes these 4 bytes so they don't cascade into bad offsets for the rest of the parse.